### PR TITLE
Don't build boost-system unless XACC build annealing libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,12 +29,20 @@ set(BOOST_LIBS_REQUIRED
   # Header only libs
   header
 )
-set(BOOST_LIBS_OPTIONAL
-  graph
-  regex
-  system
-  serialization
-)
+if(XACC_BUILD_ANNEALING)
+  set(BOOST_LIBS_OPTIONAL
+    graph
+    regex
+    system
+    serialization
+  )
+else()
+  set(BOOST_LIBS_OPTIONAL
+    graph
+    regex
+    serialization
+  )
+endif()
 
 foreach(lib ${BOOST_LIBS_REQUIRED})
   include("libs/${lib}.cmake")


### PR DESCRIPTION
Annealing does not currently have active support in XACC, and annealing is the only thing that needs Boost::system, so only build that library if XACC is building annealing (which is not done by default).